### PR TITLE
Fix _cost being redefined after reload.

### DIFF
--- a/Custom/vehicleManagementSystem/Functions/Bones_fnc_getReloadable.sqf
+++ b/Custom/vehicleManagementSystem/Functions/Bones_fnc_getReloadable.sqf
@@ -35,7 +35,7 @@ _weapArray = [];
 _vehicleMags = _vehicle call Bones_fnc_getVehicleLoadout;
 
 {
-	private ["_turretPath", "_bulletCost", "_maxMag", "_menuItem", "_magClass", "_displayName", "_ammoCount", "_magMaxAmmoCount", "_maxBullets", "_numMagsToLoad", "_currentMags", "_loadedMagCount", "_currentMagToLoad", "_currentMagCost", "_menuItemAndDetails"];
+	private ["_cost","_turretPath", "_bulletCost", "_maxMag", "_menuItem", "_magClass", "_displayName", "_ammoCount", "_magMaxAmmoCount", "_maxBullets", "_numMagsToLoad", "_currentMags", "_loadedMagCount", "_currentMagToLoad", "_currentMagCost", "_menuItemAndDetails"];
 	_turretPath = _x select 0;
 	_bulletCost = 0;
 	_cost = 0;

--- a/Custom/vehicleManagementSystem/Functions/Bones_fnc_performAction.sqf
+++ b/Custom/vehicleManagementSystem/Functions/Bones_fnc_performAction.sqf
@@ -216,6 +216,9 @@ if (_action == "refuel") then
 	_refuelDisplay = format["%1 Poptabs", _refuelCost2];
 	_reFuelButton = (findDisplay 9123 displayCtrl 1010);
 	_reFuelButton ctrlSetText _refuelDisplay;
+
+	_poptabs = (findDisplay 9123 displayCtrl 1001);
+	_poptabs ctrlSetText (format ["%1 poptabs", _exilew - _refuelCost]);
 	
 	["SuccessTitleOnly", format ["Refuelling Complete, Total Cost was %1 Poptabs", _refuelCost]] call ExileClient_gui_toaster_addTemplateToast;
 };


### PR DESCRIPTION
reload all toast message displays 0 because Bones_fnc_getReloadable redefines the value to 0